### PR TITLE
Move text recognition onto background thread

### DIFF
--- a/app/src/main/java/com/mezcode/demo/roloscan/ocrreader/StartActivity.java
+++ b/app/src/main/java/com/mezcode/demo/roloscan/ocrreader/StartActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
@@ -108,7 +109,7 @@ public class StartActivity extends AppCompatActivity {
             if (requestCode == GALLERY_REQUEST && data.getData() != null) {
                 mPhotoUri = data.getData();
             }
-            readPhoto(requestCode);
+            new ReadPhotoTask().execute(requestCode);
             return;
         } //ok result can fall through to an error
         Toast.makeText(this, R.string.returnError, Toast.LENGTH_LONG).show();
@@ -203,5 +204,15 @@ public class StartActivity extends AppCompatActivity {
         }
         return false;
     }
-
+    
+    private class ReadPhotoTask extends AsyncTask<Integer, Void, Void> {
+        @Override
+        protected Void doInBackground(Integer... params) {
+            int requestCode = params[0];
+            readPhoto(requestCode);
+            
+            return null;
+        }
+    }
+    
 }


### PR DESCRIPTION
This PR moves the processing of the received image into a background thread to prevent UI blocking. While this removes the technical issues with threads blocking, it provides a gap in the UI experience where the user is momentarily returned to the take/select photo screen with no feedback as to the status of their action. A toast or snackbar could be used, but given the short time frame before the image processing is finished and the expectation that a user only processes one photo at a time, a visual loading animation or progress bar over the take/select screen would be better suited.